### PR TITLE
Fix: Correct Transaction Type Display on Account Dashboards

### DIFF
--- a/WebContent/WEB-INF/customerPages/accountsSavingsPage.jsp
+++ b/WebContent/WEB-INF/customerPages/accountsSavingsPage.jsp
@@ -57,7 +57,7 @@
                                     <tr>
                                         <th scope="row">${loop.index + 1}</th>
                                         <td>${trans.description}</td>
-                                       <c:set var="account_number" scope="session" value="${checkingAccount.account_number}"/>
+                                       <c:set var="account_number" scope="session" value="${savingsAccount.account_number}"/>
                                         <c:set var="description" scope="session" value="${trans.description}"/>                                     
                                         <c:set var="payee_id" scope="session" value="${trans.payee_id}"/>
                                         <c:set var="payer_id" scope="session" value="${trans.payer_id}"/>


### PR DESCRIPTION
Fix(JSP): Correct transaction type display on account pages

The DEBIT/CREDIT type was being displayed from the wrong perspective on the Savings Account page.

This commit fixes the logic directly in the Checking and Saving account JSPs to ensure the correct perspective is always shown.